### PR TITLE
feat: Add very basic summarize skeleton code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ authors = [{name = "Johannes Koester", email = "johannes.koester@uni-due.de"}]
 name = "varpubs"
 requires-python = ">= 3.11"
 version = "0.1.0"
-dependencies = ["sqlmodel>=0.0.24,<0.0.25", "sqlalchemy>=2.0.39,<3", "duckdb-engine>=0.15.0,<0.16", "duckdb>=1.2.1,<2", "typed-argument-parser>=1.10.1,<2", "simple-parsing"]
+dependencies = ["sqlmodel>=0.0.24,<0.0.25", "sqlalchemy>=2.0.39,<3", "duckdb-engine>=0.15.0,<0.16", "duckdb>=1.2.1,<2", "typed-argument-parser>=1.10.1,<2", "simple-parsing", "huggingface-hub>=0.20.0,<1"]
 
 [project.scripts]
 varpubs = "varpubs.cli:main"
@@ -14,7 +14,7 @@ requires = ["hatchling"]
 
 [tool.pixi.workspace]
 channels = ["conda-forge", "bioconda"]
-platforms = ["linux-64"]
+platforms = ["linux-64", "osx-64"]
 
 [tool.pixi.pypi-dependencies]
 varpubs = { path = ".", editable = true }
@@ -23,12 +23,13 @@ varpubs = { path = ".", editable = true }
 format = "ruff format"
 lint = "ruff check"
 typecheck = "pyright"
+test = "pytest -s"
 
 [tool.pixi.feature.dev.pypi-dependencies]
 ruff = "*"
 pyright = "*"
 typing-extensions = "*"
+pytest = "*"
 
 [tool.pixi.environments]
 dev = { features = ["dev"] }
-

--- a/src/varpubs/summarize.py
+++ b/src/varpubs/summarize.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from huggingface_hub import InferenceClient
+from varpubs.pubmed_db import PubmedArticle
+
+
+@dataclass
+class HFSettings:
+    token: str
+    model: str = "HuggingFaceH4/zephyr-7b-beta"
+    max_new_tokens: int = 200
+    temperature: float = 0.1
+
+
+@dataclass
+class PubmedSummarizer:
+    settings: HFSettings
+    _client: Optional[InferenceClient] = None
+
+    @property
+    def client(self) -> InferenceClient:
+        if self._client is None:
+            self._client = InferenceClient(
+                model=self.settings.model,
+                token=self.settings.token,
+            )
+        return self._client
+
+    def summarize(self, article: PubmedArticle) -> str:
+        prompt = (
+            f"Summarize the following PubMed abstract about genetic variants:\n\n"
+            f"Title: {article.title}\n\n"
+            f"Abstract: {article.abstract}\n"
+        )
+        result = self.client.text_generation(
+            prompt,
+            max_new_tokens=self.settings.max_new_tokens,
+            temperature=self.settings.temperature,
+        )
+        return result.strip()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,21 @@
+from varpubs.pubmed_db import PubmedArticle
+from varpubs.summarize import PubmedSummarizer, HFSettings
+import os
+
+
+def test_summarization():
+    article = PubmedArticle(
+        pmid=12345678,
+        title="Genetic variants in BRCA1 and breast cancer risk",
+        abstract="BRCA1 mutations significantly increase the risk of breast and ovarian cancers. In this study, we evaluate the frequency and pathogenicity of BRCA1 variants in a European cohort consisting of 1000 participants. Out of these, 777 developed breast cancer and 123 developed ovarian cancer within 2 years.",
+        authors="Smith J, Doe A",
+        journal="Genetics Today",
+        pub_date="2023-09-15",
+        doi="10.1234/genetictoday.2023.456",
+    )
+
+    settings = HFSettings(token=os.environ["HF_TOKEN"])
+
+    summarizer = PubmedSummarizer(settings)
+    summary = summarizer.summarize(article)
+    print(summary)


### PR DESCRIPTION
This PR adds some skeleton code for summarizing an abstract from the `PubmedArticle` class. I have also set up testing with `pytest` that produces a super bad summary due to the currently used free model?

Tests can simply be run with `pixi run test`. One needs to do an export with their Huggingface token beforehand of course:

```
export HF_TOKEN=<TOKEN>
```

To get a token simply join [huggingface](https://huggingface.co/join) and then generate a token in the [settings](https://huggingface.co/settings/tokens).