### PR TITLE
fix: Fix DOI extraction from ELocationID in PubmedDB

### DIFF
--- a/src/varpubs/pubmed_db.py
+++ b/src/varpubs/pubmed_db.py
@@ -256,11 +256,14 @@ class PubmedDB:
             doi = ""
             try:
                 eloc = article.get("ELocationID", [{}])
-                if isinstance(eloc, list) and eloc and isinstance(eloc[0], dict):
-                    doi = eloc[0].get("#text", "")
+                if isinstance(eloc, list):
+                    for e in eloc:
+                        if getattr(e, "attributes", {}).get("EIdType") == "doi":
+                            doi = str(e)
+                            break
             except Exception as e:
                 logger.warning(f"DOI parse failed for PMID {pmid}: {e}")
-
+            print(doi)
             return PubmedArticle(
                 pmid=pmid,
                 title=title,


### PR DESCRIPTION
This pull request makes a targeted change to the DOI extraction logic in the `parse_article` method, improving how DOIs are parsed from the `ELocationID` field. The new approach iterates through all elements in the list to find the DOI type, rather than assuming it's always the first element.