### PR TITLE
feat: Summarize across all evidence for one specific variant of interest

### DIFF
--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -36,7 +36,7 @@ skip_if_no_api_key = pytest.mark.skipif(
 @skip_if_no_api_key
 def test_summarization():
     summarizer = PubmedSummarizer(settings())
-    summary = summarizer.summarize(ARTICLE, "G12")
+    summary = summarizer.summarize_article(ARTICLE, "G12")
     assert summary
 
 


### PR DESCRIPTION
This pull request refactors the summarization workflow to support summarizing multiple PubMed articles for a given variant term, rather than summarizing each article individually. The changes introduce a new method for summarizing a batch of articles and update the codebase to use this improved approach, resulting in more concise and informative summaries for each variant term.