### PR TITLE
fix: Split variant term into gene and hgvsp in output CSV and rename and reorder columns

### DIFF
--- a/src/varpubs/summarize_variants.py
+++ b/src/varpubs/summarize_variants.py
@@ -46,7 +46,9 @@ def summarize_variants(
                 summary = summarizer.summarize(summaries, term)
                 gene, symbol = term.split(" ")
                 rows.append(
-                    tuple([gene, symbol, summary, ",".join(f"{pmid}" for pmid in pmids)])
+                    tuple(
+                        [gene, symbol, summary, ",".join(f"{pmid}" for pmid in pmids)]
+                    )
                 )
 
         if out_path:


### PR DESCRIPTION
This pull request updates the output format of the `summarize_variants` function in `src/varpubs/summarize_variants.py` to improve clarity and consistency in the CSV output. Instead of combining the gene and symbol into a single field, the output now separates them and reorders the columns.

CSV output improvements:

* The function now splits the `term` into `gene` and `symbol` and writes them as separate columns in the output CSV.
* The CSV header is updated to `["symbol", "hgvsp", "summary", "pmids"]`, and the row order matches this header.