### PR TITLE
feat: Add article judging and ranking by relevance score based on judgements

### DIFF
--- a/src/varpubs/cli.py
+++ b/src/varpubs/cli.py
@@ -32,6 +32,7 @@ class SummarizeArgs:
     - db_path: Path to the existing DuckDB database file.
     - vcf_path: A single annotated VCF file with variant terms.
     - api_key: Hugging Face API token for model access.
+    - judges: List of judges for ranking articles (e.g., "therapy relevance"1)
     - llm_url: Base URL for LLM API (Must follow the openai API format)
     - model: The LLM model used for summarization (default: medgemma-27b-it).
     - role: The professional role or perspective the LLM should take (default: physician).
@@ -43,6 +44,7 @@ class SummarizeArgs:
     llm_url: str
     model: str = "medgemma-27b-it"
     role: str = "physician"
+    judges: Optional[list[str]] = None
     api_key: Optional[str] = ""
     output: Optional[Path] = None
 
@@ -108,5 +110,6 @@ def main():
             db_path=args.args.db_path,
             vcf_path=args.args.vcf_path,
             summarizer=summarizer,
+            judges=args.args.judges,
             out_path=args.args.output,
         )

--- a/src/varpubs/summarize_variants.py
+++ b/src/varpubs/summarize_variants.py
@@ -53,9 +53,7 @@ def summarize_variants(
                 key=lambda x: sum(x[1]["scores"].values()) / len(x[1]["scores"]),
                 reverse=True,
             )[:50]
-            top_summaries = [
-                (pmid, data["summary"]) for pmid, data in top_summaries
-            ]
+            top_summaries = [(pmid, data["summary"]) for pmid, data in top_summaries]
 
             if top_summaries:
                 summary = summarizer.summarize(top_summaries, term)

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -34,6 +34,13 @@ skip_if_no_api_key = pytest.mark.skipif(
 
 
 @skip_if_no_api_key
+def test_judgment():
+    summarizer = PubmedSummarizer(settings())
+    score = summarizer.judge(ARTICLE, "therapy related")
+    assert score > 5
+
+
+@skip_if_no_api_key
 def test_summarization():
     summarizer = PubmedSummarizer(settings())
     summary = summarizer.summarize_article(ARTICLE, "G12")


### PR DESCRIPTION
This pull request introduces a new article ranking feature to the variant summarization workflow. The main enhancement is the ability to judge and rank PubMed articles based on their relevance to specified criteria ("judges"), improving the selection of articles for summarization. The changes add support for passing a list of judges through the CLI, implement a relevance scoring function using the LLM, and update the summarization logic to use these scores for ranking.