### PR TITLE
fix: Fix sorting when scores dict is empty in summarize_variants

### DIFF
--- a/src/varpubs/summarize_variants.py
+++ b/src/varpubs/summarize_variants.py
@@ -50,7 +50,7 @@ def summarize_variants(
                 summaries[pmid] = {"summary": summary_text, "scores": scores}
             top_summaries = sorted(
                 summaries.items(),
-                key=lambda x: sum(x[1]["scores"].values()) / len(x[1]["scores"]),
+                key=lambda x: sum(x[1]["scores"].values()) if x[1]["scores"] else 0,
                 reverse=True,
             )[:50]
             top_summaries = [(pmid, data["summary"]) for pmid, data in top_summaries]


### PR DESCRIPTION
This pull request makes a small change to the sorting logic in the `summarize_variants` function. The update improves how top summaries are selected when score data is missing, ensuring that entries without scores are handled gracefully.