### PR TITLE
feat: Output per-judge bullet point summaries

### DIFF
--- a/src/varpubs/cli.py
+++ b/src/varpubs/cli.py
@@ -52,10 +52,10 @@ class SummarizeArgs:
     output: Path
     cache: Optional[Path]
     llm_url: str
+    judges: List[str]
     species: str = "human"
     model: str = "medgemma-27b-it"
     role: str = "physician"
-    judges: Optional[List[str]] = None
     api_key: Optional[str] = ""
     output_cache: Optional[Path] = None
 

--- a/src/varpubs/summarize.py
+++ b/src/varpubs/summarize.py
@@ -3,7 +3,7 @@ from typing import Optional
 from openai import OpenAI
 from string import Template
 from varpubs.pubmed_db import PubmedArticle
-from varpubs.cache import Cache
+from varpubs.cache import Cache, Judge
 import re
 import logging
 import hashlib
@@ -32,24 +32,23 @@ class PubmedSummarizer:
         return f"You are an {self.settings.role}."
 
     def summarize(
-        self, texts: list[tuple[PubmedArticle, str]], term: str, retries=3
+        self, texts: list[tuple[PubmedArticle, str]], term: str, judge: str, retries=3,
     ) -> str:
         summaries = "\n".join(
             f"{article.pmid}: {summary}" for article, summary in texts
         )
         input_text = (
             f"Take the following summaries of PubMed articles related to {term}"
-            "Write only ONE single coherent paragraph.\n"
+            f"Write a short and concise bullet point based summary under the aspect of: {judge}.\n"
             "Requirements:\n"
             "- REMOVE all irrelevant information.\n"
             "- DO NOT add introductory phrases (e.g., 'the provided text discusses', 'here is a summary').\n"
-            "- DO NOT list results. NO bullet points. NO multiple paragraphs.\n"
             "- Synthesise the information: merge overlapping findings, highlight agreements or contradictions.\n"
             "- Be concise but informative. Focus on biologically and clinically meaningful insights only.\n"
-            "- When referring to information from an article, cite the PMID in parentheses (PMID:XXXXX).\n"
-            "- Only output the paragraph. No meta-commentary.\n\n"
+            "- ALWAYS cite the PMID in parentheses (PMID:XXXXX) when referring to information from an article,.\n"
+            "- Only output the bullet points each starting with a - character. No meta-commentary.\n\n"
             f"Article summaries:\n{summaries}\n\n"
-            "Now write the summary paragraph:"
+            "Now write the summary bullet points:"
         )
         message = ""
         for retry in range(retries):

--- a/src/varpubs/summarize.py
+++ b/src/varpubs/summarize.py
@@ -3,7 +3,7 @@ from typing import Optional
 from openai import OpenAI
 from string import Template
 from varpubs.pubmed_db import PubmedArticle
-from varpubs.cache import Cache, Judge
+from varpubs.cache import Cache
 import re
 import logging
 import hashlib

--- a/src/varpubs/summarize.py
+++ b/src/varpubs/summarize.py
@@ -32,7 +32,11 @@ class PubmedSummarizer:
         return f"You are an {self.settings.role}."
 
     def summarize(
-        self, texts: list[tuple[PubmedArticle, str]], term: str, judge: str, retries=3,
+        self,
+        texts: list[tuple[PubmedArticle, str]],
+        term: str,
+        judge: str,
+        retries=3,
     ) -> str:
         summaries = "\n".join(
             f"{article.pmid}: {summary}" for article, summary in texts

--- a/src/varpubs/summarize_variants.py
+++ b/src/varpubs/summarize_variants.py
@@ -42,16 +42,16 @@ def summarize_variants(
     vcf_path: Path,
     summarizer: PubmedSummarizer,
     species: str,
+    judges: List[str],
     out_path: Optional[Path] = None,
-    judges: Optional[List[str]] = None,
     output_cache: Optional[Path] = None,
 ):
     """
     Extracts variant terms from a VCF file, finds related PubMed articles from the database,
     summarizes them using the given summarizer, and optionally saves the summaries to a CSV file.
     """
-    if judges is None:
-        judges = []
+    if not judges:
+        raise ValueError("At least one judge must be specified for summarization.")
     db = PubmedDB(path=db_path, vcf_paths=[], species=species, max_publications=50)
     engine = db.engine
     cache = summarizer.settings.cache
@@ -169,20 +169,21 @@ def summarize_variants(
                             "scores": scores,
                             "term": bioconcept,
                         }
-                    pmids_summaries: List[Tuple[PubmedArticle, str]] = [
-                        (data["article"], data["summary"])
-                        for data in summaries.values()
-                    ]
                     judge_scores: List[Dict[str, int]] = [
                         data["scores"] for data in summaries.values()
                     ]
 
                     hgvs, gene = bioconcept_to_hgvsp_gene(bioconcept)
-                    final_summary = (
-                        summarizer.summarize(pmids_summaries, f"{gene} {hgvs}")
-                        if pmids_summaries
-                        else ""
-                    )
+                    final_summary = ""
+                    for judge in judges:
+                        relevant_summaries = [
+                            (data["article"], data["summary"])
+                            for data in summaries.values()
+                            if data["scores"].get(judge) > 1
+                        ]
+                        judge_term_summary = summarizer.summarize(relevant_summaries, f"{gene} {hgvs}", judge)
+                        final_summary += f"{judge}:\n\n{judge_term_summary}\n\n"
+
                     transcript_records[bioconcept] = TranscriptRecord(
                         pmids=pmids,
                         summary=final_summary.replace(",", "%2C"),

--- a/src/varpubs/summarize_variants.py
+++ b/src/varpubs/summarize_variants.py
@@ -1,7 +1,7 @@
 import logging
 from statistics import mean
 from pathlib import Path
-from typing import List, Optional, Dict, Tuple, Set
+from typing import List, Optional, Dict, Set
 from dataclasses import dataclass
 
 from sqlmodel import Session, select

--- a/src/varpubs/summarize_variants.py
+++ b/src/varpubs/summarize_variants.py
@@ -181,7 +181,9 @@ def summarize_variants(
                             for data in summaries.values()
                             if data["scores"].get(judge) > 1
                         ]
-                        judge_term_summary = summarizer.summarize(relevant_summaries, f"{gene} {hgvs}", judge)
+                        judge_term_summary = summarizer.summarize(
+                            relevant_summaries, f"{gene} {hgvs}", judge
+                        )
                         final_summary += f"{judge}:\n\n{judge_term_summary}\n\n"
 
                     transcript_records[bioconcept] = TranscriptRecord(


### PR DESCRIPTION
This pull request refactors the variant summarization pipeline to support multiple judge perspectives and improves the flexibility and clarity of summaries as they are filtered using the judge score before being passed into the final summary. The main changes include requiring explicit judge selection, updating the summary format to bullet points per judge, and adjusting function signatures and logic accordingly.