### PR TITLE
feat: Handle truncated responses and expose LLM settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,13 @@ varpubs summarize-variants \
   --api-key $HF_TOKEN \
   --model medgemma-27b-it \
   --role physician \
+  --judges "therapy relevance" \
   --cache cache.duckdb \
   --output summaries.vcf \
   --output-cache tmp_cache.duckdb
 ```
+
+Each LLM call starts with a budget of `--max-new-tokens` (default 500) and doubles it on every `--retries` attempt (default 3) if the response was cut off. Responses still truncated after the last attempt are discarded. Model reasoning is disabled by default and can be enabled via `--enable-thinking true`.
 
 ### 3. Merge or update caches
 ```bash

--- a/src/varpubs/cli.py
+++ b/src/varpubs/cli.py
@@ -45,6 +45,9 @@ class SummarizeArgs:
     - model: The LLM model used for summarization (default: medgemma-27b-it).
     - role: The professional role or perspective the LLM should take (default: physician).
     - output_cache: Optional path to save the cache file for storing new summary results.
+    - max_new_tokens: Token budget for the first attempt of each LLM call (default: 500).
+    - retries: Attempts per LLM call, doubling the token budget each time (default: 3).
+    - enable_thinking: Enable reasoning for models that support it (default: False).
     """
 
     db_path: Path
@@ -58,6 +61,9 @@ class SummarizeArgs:
     role: str = "physician"
     api_key: Optional[str] = ""
     output_cache: Optional[Path] = None
+    max_new_tokens: int = 500
+    retries: int = 3
+    enable_thinking: bool = False
 
 
 @dataclass
@@ -147,6 +153,9 @@ def main():
                 base_url=args.args.llm_url,
                 role=args.args.role,
                 cache=cache,
+                max_new_tokens=args.args.max_new_tokens,
+                retries=args.args.retries,
+                enable_thinking=args.args.enable_thinking,
             )
         )
 

--- a/src/varpubs/summarize.py
+++ b/src/varpubs/summarize.py
@@ -8,6 +8,8 @@ import re
 import logging
 import hashlib
 
+THINKING = re.compile(r"<think>.*?</think>", re.DOTALL)
+
 
 @dataclass
 class Settings:
@@ -42,6 +44,36 @@ class PubmedSummarizer:
     def instruction(self) -> str:
         return f"You are an {self.settings.role}."
 
+    def complete(
+        self,
+        input_text: str,
+        instruction: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+    ) -> Optional[str]:
+        for retry in range(self.settings.retries):
+            budget = max_tokens or self.max_tokens(retry)
+            response = self.client.chat.completions.create(
+                model=self.settings.model,
+                messages=[
+                    {"role": "system", "content": instruction or self.instruction()},
+                    {"role": "user", "content": input_text},
+                ],
+                max_tokens=budget,
+                temperature=self.settings.temperature
+                if temperature is None
+                else temperature,
+                extra_body=self.extra_body,
+            )
+            choice = response.choices[0]
+            if choice.finish_reason == "length":
+                logging.info(
+                    f"LLM response truncated with max tokens {budget}. Retrying with {max_tokens or self.max_tokens(retry + 1)}"
+                )
+                continue
+            return THINKING.sub("", choice.message.content or "").strip()
+        return None
+
     def summarize(
         self,
         texts: list[tuple[PubmedArticle, str]],
@@ -64,26 +96,11 @@ class PubmedSummarizer:
             f"Article summaries:\n{summaries}\n\n"
             "Now write the summary bullet points:"
         )
-        for retry in range(self.settings.retries):
-            response = self.client.chat.completions.create(
-                model=self.settings.model,
-                messages=[
-                    {"role": "system", "content": self.instruction()},
-                    {"role": "user", "content": input_text},
-                ],
-                max_tokens=self.max_tokens(retry),
-                temperature=self.settings.temperature,
-                extra_body=self.extra_body,
-            )
-            choice = response.choices[0]
-            if choice.finish_reason == "length":
-                logging.info(
-                    f"LLM response truncated with max tokens {self.max_tokens(retry)}. Retrying with {self.max_tokens(retry + 1)}"
-                )
-                continue
-            return choice.message.content or ""
-        logging.warning("Max token limit reached. Discarding truncated summary.")
-        return ""
+        message = self.complete(input_text)
+        if message is None:
+            logging.warning("Max token limit reached. Discarding truncated summary.")
+            return ""
+        return message
 
     def summary_prompt_template(self) -> Template:
         """Return a template for generating a summary prompt."""
@@ -112,23 +129,13 @@ class PubmedSummarizer:
             abstract=article.abstract or "",
         )
 
-        response = self.client.chat.completions.create(
-            model=self.settings.model,
-            messages=[
-                {"role": "system", "content": self.instruction()},
-                {"role": "user", "content": input_text},
-            ],
-            temperature=self.settings.temperature,
-            max_tokens=self.max_tokens(),
-            extra_body=self.extra_body,
-        )
-        choice = response.choices[0]
-        if choice.finish_reason == "length":
+        message = self.complete(input_text)
+        if message is None:
             logging.warning(
                 f"Truncated summary for article {article.pmid}. Discarding."
             )
             return ""
-        return choice.message.content or ""
+        return message
 
     def judge_prompt_template(self) -> Template:
         return Template(
@@ -155,30 +162,15 @@ class PubmedSummarizer:
         input_text = template.substitute(
             term=term, title=article.title, abstract=article.abstract
         )
-        for retry in range(self.settings.retries):
-            response = self.client.chat.completions.create(
-                model=self.settings.model,
-                messages=[
-                    {"role": "system", "content": self.instruction()},
-                    {"role": "user", "content": input_text},
-                ],
-                max_tokens=self.max_tokens(retry),
-                temperature=self.settings.temperature,
-                extra_body=self.extra_body,
-            )
-            choice = response.choices[0]
-            if choice.finish_reason == "length":
-                logging.info(
-                    f"LLM response truncated with max tokens {self.max_tokens(retry)}. Retrying with {self.max_tokens(retry + 1)}"
-                )
-                continue
-            message = choice.message.content or ""
-            scores = re.findall(r"\b[1-4]\b", message)
-            if scores:
-                return int(scores[-1])
+        message = self.complete(input_text)
+        if message is None:
+            logging.warning(f"Could not judge article {article.pmid} against '{term}'.")
+            return None
+        scores = re.findall(r"\b[1-4]\b", message)
+        if not scores:
             logging.warning(f"Could not parse judgment from model response: {message}")
-        logging.warning(f"Could not judge article {article.pmid} against '{term}'.")
-        return None
+            return None
+        return int(scores[-1])
 
     def validate_summary(self, abstract: str, summary: str) -> bool:
         few_shots = [
@@ -264,16 +256,7 @@ class PubmedSummarizer:
             "Is the summary factually accurate based on the abstract?"
         )
 
-        response = self.client.chat.completions.create(
-            model=self.settings.model,
-            messages=[
-                {"role": "system", "content": instruction_text},
-                {"role": "user", "content": user_prompt},
-            ],
-            temperature=1,
-            max_tokens=5,
-            extra_body=self.extra_body,
+        answer = self.complete(
+            user_prompt, instruction=instruction_text, max_tokens=5, temperature=1
         )
-        content = response.choices[0].message.content or ""
-        answer = content.strip().lower()
-        return answer == "true"
+        return (answer or "").strip().lower() == "true"

--- a/src/varpubs/summarize.py
+++ b/src/varpubs/summarize.py
@@ -66,7 +66,7 @@ class PubmedSummarizer:
                 temperature=self.settings.temperature,
             )
             choice = response.choices[0]
-            message = str(choice.message.content)
+            message = choice.message.content or ""
             if choice.finish_reason == "length":
                 logging.info(
                     f"LLM response truncated with max tokens {self.settings.max_new_tokens + 500 * retry}. Retrying with {self.settings.max_new_tokens + 500 * (retry + 1)}"
@@ -74,8 +74,8 @@ class PubmedSummarizer:
                 continue
             else:
                 return message
-        logging.warn("Message might be truncate. Max token limit reached.")
-        return message
+        logging.warning("Max token limit reached. Discarding truncated summary.")
+        return ""
 
     def summary_prompt_template(self) -> Template:
         """Return a template for generating a summary prompt."""
@@ -113,7 +113,13 @@ class PubmedSummarizer:
             temperature=self.settings.temperature,
             max_tokens=self.settings.max_new_tokens,
         )
-        return str(response.choices[0].message.content)
+        choice = response.choices[0]
+        if choice.finish_reason == "length":
+            logging.warning(
+                f"Truncated summary for article {article.pmid}. Discarding."
+            )
+            return ""
+        return choice.message.content or ""
 
     def judge_prompt_template(self) -> Template:
         return Template(
@@ -152,7 +158,7 @@ class PubmedSummarizer:
                     temperature=self.settings.temperature,
                 )
                 choice = response.choices[0]
-                message = str(choice.message.content)
+                message = choice.message.content or ""
                 if choice.finish_reason == "length":
                     logging.info(
                         f"LLM response truncated with max tokens {self.settings.max_new_tokens + 500 * retry}. Retrying with {self.settings.max_new_tokens + 500 * (retry + 1)}"

--- a/src/varpubs/summarize.py
+++ b/src/varpubs/summarize.py
@@ -150,44 +150,35 @@ class PubmedSummarizer:
         template_text = self.judge_prompt_template().template
         return hashlib.sha256(template_text.encode("utf-8")).hexdigest()
 
-    def judge(self, article: PubmedArticle, term: str) -> int:
-        retries = self.settings.retries
-        for _ in range(retries):
-            template = self.judge_prompt_template()
-            input_text = template.substitute(
-                term=term, title=article.title, abstract=article.abstract
-            )
-            for retry in range(retries):
-                response = self.client.chat.completions.create(
-                    model=self.settings.model,
-                    messages=[
-                        {"role": "system", "content": self.instruction()},
-                        {"role": "user", "content": input_text},
-                    ],
-                    max_tokens=self.max_tokens(retry),
-                    temperature=self.settings.temperature,
-                    extra_body=self.extra_body,
-                )
-                choice = response.choices[0]
-                message = choice.message.content or ""
-                if choice.finish_reason == "length":
-                    logging.info(
-                        f"LLM response truncated with max tokens {self.max_tokens(retry)}. Retrying with {self.max_tokens(retry + 1)}"
-                    )
-                    continue
-                else:
-                    match = re.search(r"\b([1-4])\b", message)
-                    if match:
-                        score = int(match.group())
-                        return max(1, min(4, score))
-                    else:
-                        logging.warning(
-                            f"Could not parse judgment from model response: {message}"
-                        )
-
-        raise ValueError(
-            f"Could not parse judgment from model response after {retries} retries."
+    def judge(self, article: PubmedArticle, term: str) -> Optional[int]:
+        template = self.judge_prompt_template()
+        input_text = template.substitute(
+            term=term, title=article.title, abstract=article.abstract
         )
+        for retry in range(self.settings.retries):
+            response = self.client.chat.completions.create(
+                model=self.settings.model,
+                messages=[
+                    {"role": "system", "content": self.instruction()},
+                    {"role": "user", "content": input_text},
+                ],
+                max_tokens=self.max_tokens(retry),
+                temperature=self.settings.temperature,
+                extra_body=self.extra_body,
+            )
+            choice = response.choices[0]
+            if choice.finish_reason == "length":
+                logging.info(
+                    f"LLM response truncated with max tokens {self.max_tokens(retry)}. Retrying with {self.max_tokens(retry + 1)}"
+                )
+                continue
+            message = choice.message.content or ""
+            scores = re.findall(r"\b[1-4]\b", message)
+            if scores:
+                return int(scores[-1])
+            logging.warning(f"Could not parse judgment from model response: {message}")
+        logging.warning(f"Could not judge article {article.pmid} against '{term}'.")
+        return None
 
     def validate_summary(self, abstract: str, summary: str) -> bool:
         few_shots = [

--- a/src/varpubs/summarize.py
+++ b/src/varpubs/summarize.py
@@ -18,6 +18,8 @@ class Settings:
     max_new_tokens: int = 500
     temperature: float = 0.1
     cache: Optional[Cache] = None
+    retries: int = 3
+    enable_thinking: bool = False
 
 
 @dataclass
@@ -28,6 +30,15 @@ class PubmedSummarizer:
     def client(self) -> OpenAI:
         return OpenAI(api_key=self.settings.api_key, base_url=self.settings.base_url)
 
+    @property
+    def extra_body(self) -> dict:
+        return {
+            "chat_template_kwargs": {"enable_thinking": self.settings.enable_thinking}
+        }
+
+    def max_tokens(self, retry: int = 0) -> int:
+        return self.settings.max_new_tokens * 2**retry
+
     def instruction(self) -> str:
         return f"You are an {self.settings.role}."
 
@@ -36,7 +47,6 @@ class PubmedSummarizer:
         texts: list[tuple[PubmedArticle, str]],
         term: str,
         judge: str,
-        retries=3,
     ) -> str:
         summaries = "\n".join(
             f"{article.pmid}: {summary}" for article, summary in texts
@@ -54,26 +64,24 @@ class PubmedSummarizer:
             f"Article summaries:\n{summaries}\n\n"
             "Now write the summary bullet points:"
         )
-        message = ""
-        for retry in range(retries):
+        for retry in range(self.settings.retries):
             response = self.client.chat.completions.create(
                 model=self.settings.model,
                 messages=[
                     {"role": "system", "content": self.instruction()},
                     {"role": "user", "content": input_text},
                 ],
-                max_tokens=self.settings.max_new_tokens + 500 * retry,
+                max_tokens=self.max_tokens(retry),
                 temperature=self.settings.temperature,
+                extra_body=self.extra_body,
             )
             choice = response.choices[0]
-            message = choice.message.content or ""
             if choice.finish_reason == "length":
                 logging.info(
-                    f"LLM response truncated with max tokens {self.settings.max_new_tokens + 500 * retry}. Retrying with {self.settings.max_new_tokens + 500 * (retry + 1)}"
+                    f"LLM response truncated with max tokens {self.max_tokens(retry)}. Retrying with {self.max_tokens(retry + 1)}"
                 )
                 continue
-            else:
-                return message
+            return choice.message.content or ""
         logging.warning("Max token limit reached. Discarding truncated summary.")
         return ""
 
@@ -111,7 +119,8 @@ class PubmedSummarizer:
                 {"role": "user", "content": input_text},
             ],
             temperature=self.settings.temperature,
-            max_tokens=self.settings.max_new_tokens,
+            max_tokens=self.max_tokens(),
+            extra_body=self.extra_body,
         )
         choice = response.choices[0]
         if choice.finish_reason == "length":
@@ -141,7 +150,8 @@ class PubmedSummarizer:
         template_text = self.judge_prompt_template().template
         return hashlib.sha256(template_text.encode("utf-8")).hexdigest()
 
-    def judge(self, article: PubmedArticle, term: str, retries: int = 3) -> int:
+    def judge(self, article: PubmedArticle, term: str) -> int:
+        retries = self.settings.retries
         for _ in range(retries):
             template = self.judge_prompt_template()
             input_text = template.substitute(
@@ -154,14 +164,15 @@ class PubmedSummarizer:
                         {"role": "system", "content": self.instruction()},
                         {"role": "user", "content": input_text},
                     ],
-                    max_tokens=self.settings.max_new_tokens + 500 * retry,
+                    max_tokens=self.max_tokens(retry),
                     temperature=self.settings.temperature,
+                    extra_body=self.extra_body,
                 )
                 choice = response.choices[0]
                 message = choice.message.content or ""
                 if choice.finish_reason == "length":
                     logging.info(
-                        f"LLM response truncated with max tokens {self.settings.max_new_tokens + 500 * retry}. Retrying with {self.settings.max_new_tokens + 500 * (retry + 1)}"
+                        f"LLM response truncated with max tokens {self.max_tokens(retry)}. Retrying with {self.max_tokens(retry + 1)}"
                     )
                     continue
                 else:
@@ -270,6 +281,7 @@ class PubmedSummarizer:
             ],
             temperature=1,
             max_tokens=5,
+            extra_body=self.extra_body,
         )
         content = response.choices[0].message.content or ""
         answer = content.strip().lower()

--- a/src/varpubs/summarize_variants.py
+++ b/src/varpubs/summarize_variants.py
@@ -203,6 +203,7 @@ def summarize_variants(
                                 prompt_hash=summarizer.summary_prompt_hash(),
                             )
                             for pmid, data in summaries.items()
+                            if data["summary"]
                         ]
                         ocache.write_summaries(s)
                         ocache.write_judges([Judge(**j) for j in judgements])

--- a/src/varpubs/summarize_variants.py
+++ b/src/varpubs/summarize_variants.py
@@ -152,17 +152,18 @@ def summarize_variants(
                             )
                             if not score:
                                 score = summarizer.judge(article, judge)
-                                judgements.append(
-                                    Judge(
-                                        term=bioconcept,
-                                        pmid=pmid,
-                                        model=summarizer.settings.model,
-                                        judge=judge,
-                                        score=score,
-                                        prompt_hash=summarizer.judge_prompt_hash(),
-                                    ).model_dump()
-                                )
-                            scores[judge] = score
+                                if score:
+                                    judgements.append(
+                                        Judge(
+                                            term=bioconcept,
+                                            pmid=pmid,
+                                            model=summarizer.settings.model,
+                                            judge=judge,
+                                            score=score,
+                                            prompt_hash=summarizer.judge_prompt_hash(),
+                                        ).model_dump()
+                                    )
+                            scores[judge] = score or 1
                         summaries[pmid] = {
                             "article": article,
                             "summary": summary_text,

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -48,6 +48,7 @@ skip_if_no_api_key = pytest.mark.skipif(
 def test_positive_judgment():
     summarizer = PubmedSummarizer(settings())
     score = summarizer.judge(ARTICLE, "therapy related")
+    assert score is not None
     assert score > 1
 
 
@@ -55,6 +56,7 @@ def test_positive_judgment():
 def test_negative_judgment():
     summarizer = PubmedSummarizer(settings())
     score = summarizer.judge(THERAPY_UNRELATED_ARTICLE, "therapy unrelated")
+    assert score is not None
     assert score < 2
 
 


### PR DESCRIPTION
This PR fixes summaries showing up as the literal string "None" or as cut-off text, which happened when a reasoning model spent its whole token budget thinking before writing an answer. Truncated and empty responses are now discarded instead of written to the VCF and cache, judgment scores are read from the end of the response rather than the start (where they were being scraped out of the model's thinking block) and reasoning is disabled by default. Token budget, retries and thinking are now configurable via `--max_new_tokens`, `--retries` and `--enable_thinking`.